### PR TITLE
feat(user): issue kubeconfigs with token requests

### DIFF
--- a/controllers/user/api/v1/user_types.go
+++ b/controllers/user/api/v1/user_types.go
@@ -23,20 +23,22 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const DefaultCSRExpirationSeconds int32 = 1_000_000_000
+
 // UserSpec defines the desired state of User
 type UserSpec struct {
 	// expirationSeconds is the requested duration of validity of the issued
-	// certificate. The certificate signer may issue a certificate with a different
-	// validity duration so a client must check the delta between the notBefore and
-	// notAfter fields in the issued certificate to determine the actual duration.
+	// kubeconfig credential. The issuer may issue a credential with a different
+	// validity duration so a client must check the issued credential to determine
+	// the actual duration.
 	//
 	// The minimum valid value for expirationSeconds is 600, i.e. 10 minutes.
 	//
 	// +optional
-	//+kubebuilder:default:=7200
+	//+kubebuilder:default:=1000000000
 	CSRExpirationSeconds int32 `json:"csrExpirationSeconds,omitempty"`
 	// kubeConfigRotateAt 用于手动触发 kubeconfig 轮转。
-	// 当字段被设置或更新时，controller 会重建 token Secret 与 kubeconfig。
+	// 当字段被设置或更新时，controller 会重新请求 token 并重建 kubeconfig。
 	// +optional
 	KubeConfigRotateAt *metav1.Time `json:"kubeConfigRotateAt,omitempty"`
 }
@@ -63,7 +65,7 @@ type UserStatus struct {
 	//+kubebuilder:default:=Unknown
 	Phase      UserPhase `json:"phase,omitempty"`
 	KubeConfig string    `json:"kubeConfig"`
-	//+kubebuilder:default:=7200
+	//+kubebuilder:default:=1000000000
 	ObservedCSRExpirationSeconds int32 `json:"observedCSRExpirationSeconds,omitempty"`
 	// ObservedKubeConfigRotateAt 记录已处理的轮转请求时间戳。
 	// +optional

--- a/controllers/user/api/v1/user_webhook.go
+++ b/controllers/user/api/v1/user_webhook.go
@@ -80,7 +80,7 @@ func (r *User) Default(ctx context.Context, obj runtime.Object) error {
 	userlog.Info("default", "name", user.Name)
 	user.ObjectMeta = initAnnotationAndLabels(user.ObjectMeta)
 	if user.Spec.CSRExpirationSeconds == 0 {
-		user.Spec.CSRExpirationSeconds = 7200
+		user.Spec.CSRExpirationSeconds = DefaultCSRExpirationSeconds
 	}
 	if user.Annotations[UserAnnotationDisplayKey] == "" {
 		user.Annotations[UserAnnotationDisplayKey] = user.Name

--- a/controllers/user/config/crd/bases/user.sealos.io_users.yaml
+++ b/controllers/user/config/crd/bases/user.sealos.io_users.yaml
@@ -64,12 +64,12 @@ spec:
             description: UserSpec defines the desired state of User
             properties:
               csrExpirationSeconds:
-                default: 7200
+                default: 1000000000
                 description: |-
                   expirationSeconds is the requested duration of validity of the issued
-                  certificate. The certificate signer may issue a certificate with a different
-                  validity duration so a client must check the delta between the notBefore and
-                  notAfter fields in the issued certificate to determine the actual duration.
+                  kubeconfig credential. The issuer may issue a credential with a different
+                  validity duration so a client must check the issued credential to determine
+                  the actual duration.
 
 
                   The minimum valid value for expirationSeconds is 600, i.e. 10 minutes.
@@ -77,8 +77,8 @@ spec:
                 type: integer
               kubeConfigRotateAt:
                 description: kubeConfigRotateAt is a manual trigger for kubeconfig
-                  rotation. When set/updated, controller will recreate token secret
-                  and kubeconfig.
+                  rotation. When set/updated, controller will request a new token
+                  and recreate kubeconfig.
                 format: date-time
                 type: string
             type: object
@@ -122,7 +122,7 @@ spec:
               kubeConfig:
                 type: string
               observedCSRExpirationSeconds:
-                default: 7200
+                default: 1000000000
                 format: int32
                 type: integer
               observedKubeConfigRotateAt:

--- a/controllers/user/controllers/helper/kubeconfig/interface.go
+++ b/controllers/user/controllers/helper/kubeconfig/interface.go
@@ -17,12 +17,14 @@ limitations under the License.
 package kubeconfig
 
 import (
+	"context"
 	"net"
 	"os"
-	"time"
 
+	userv1 "github.com/labring/sealos/controllers/user/api/v1"
 	csrv1 "k8s.io/api/certificates/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd/api"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -33,6 +35,11 @@ var defaultLog = ctrl.Log.WithName("kubeconfig")
 
 type Interface interface {
 	Apply(config *rest.Config, client client.Client) (*api.Config, error)
+}
+
+type TokenRequestInterface interface {
+	Interface
+	ApplyWithTokenRequest(ctx context.Context, config *rest.Config, client client.Client) (*api.Config, metav1.Time, error)
 }
 
 type CertConfig struct {
@@ -56,9 +63,8 @@ type CsrConfig struct {
 }
 type ServiceAccountConfig struct {
 	*DefaultConfig
-	namespace  string
-	sa         *v1.ServiceAccount
-	secretName string
+	namespace string
+	sa        *v1.ServiceAccount
 }
 
 type WebhookConfig struct {
@@ -89,7 +95,7 @@ func NewConfig(user, clusterName string, expirationSeconds int32) *DefaultConfig
 		clusterName = "sealos"
 	}
 	if expirationSeconds == 0 {
-		expirationSeconds = int32(2 * time.Hour.Seconds())
+		expirationSeconds = userv1.DefaultCSRExpirationSeconds
 	}
 	return &DefaultConfig{
 		user:              user,

--- a/controllers/user/controllers/helper/kubeconfig/sa.go
+++ b/controllers/user/controllers/helper/kubeconfig/sa.go
@@ -19,14 +19,16 @@ package kubeconfig
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"time"
 
+	userv1 "github.com/labring/sealos/controllers/user/api/v1"
 	config2 "github.com/labring/sealos/controllers/user/controllers/helper/config"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -35,19 +37,27 @@ func (sac *ServiceAccountConfig) Apply(
 	config *rest.Config,
 	client client.Client,
 ) (*api.Config, error) {
+	cfg, _, err := sac.ApplyWithTokenRequest(context.Background(), config, client)
+	return cfg, err
+}
+
+func (sac *ServiceAccountConfig) ApplyWithTokenRequest(
+	ctx context.Context,
+	config *rest.Config,
+	client client.Client,
+) (*api.Config, metav1.Time, error) {
 	if err := sac.applyServiceAccount(config, client); err != nil {
-		return nil, fmt.Errorf("failed to apply service account error: %w", err)
+		return nil, metav1.Time{}, fmt.Errorf("failed to apply service account error: %w", err)
 	}
-	if err := sac.applySecret(config, client); err != nil {
-		return nil, fmt.Errorf("failed to apply secret: %w", err)
+	tokenRequest, err := sac.requestToken(ctx, config)
+	if err != nil {
+		return nil, metav1.Time{}, fmt.Errorf("failed to fetch token: %w", err)
 	}
-	token, err := sac.fetchToken(client)
-	if err == nil {
-		if cfg, err := sac.generatorKubeConfig(config, token); err == nil {
-			return cfg, nil
-		}
+	cfg, err := sac.generatorKubeConfig(config, tokenRequest.Status.Token)
+	if err != nil {
+		return nil, metav1.Time{}, fmt.Errorf("failed to generate kube config: %w", err)
 	}
-	return nil, fmt.Errorf("failed to fetch token: %v", err)
+	return cfg, tokenRequest.Status.ExpirationTimestamp, nil
 }
 
 func (sac *ServiceAccountConfig) applyServiceAccount(_ *rest.Config, client client.Client) error {
@@ -61,90 +71,38 @@ func (sac *ServiceAccountConfig) applyServiceAccount(_ *rest.Config, client clie
 		},
 	}
 	_, err := controllerutil.CreateOrUpdate(context.TODO(), client, sa, func() error {
-		if len(sa.Secrets) == 0 {
-			sa.Secrets = []v1.ObjectReference{
-				{
-					Name: sac.getSecretName(),
-				},
-			}
-		}
 		return nil
 	})
-	sac.secretName = sa.Secrets[0].Name
+	sac.sa = sa
 	return err
 }
 
-func (sac *ServiceAccountConfig) applySecret(_ *rest.Config, client client.Client) error {
-	if sac.sa != nil {
-		return nil
+func (sac *ServiceAccountConfig) requestToken(ctx context.Context, config *rest.Config) (*authenticationv1.TokenRequest, error) {
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
 	}
-	secret := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      sac.secretName,
-			Namespace: sac.namespace,
-		},
+	tokenRequest, err := clientset.CoreV1().
+		ServiceAccounts(sac.namespace).
+		CreateToken(ctx, sac.user, &authenticationv1.TokenRequest{
+			Spec: authenticationv1.TokenRequestSpec{
+				ExpirationSeconds: ptr.To(int64(sac.tokenRequestExpirationSeconds())),
+			},
+		}, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
 	}
-	_, err := controllerutil.CreateOrUpdate(context.TODO(), client, secret, func() error {
-		if secret.Annotations == nil {
-			secret.Annotations = make(map[string]string, 0)
-		}
-		secret.Type = v1.SecretTypeServiceAccountToken
-		secret.Annotations[v1.ServiceAccountNameKey] = sac.user
-		secret.Annotations["sealos.io/user.expirationSeconds"] = strconv.Itoa(
-			int(sac.expirationSeconds),
-		)
-		return nil
-	})
-	sac.sa = &v1.ServiceAccount{}
-	sac.sa.Name = sac.user
-	sac.sa.Namespace = sac.namespace
-	return err
+	if tokenRequest.Status.Token == "" {
+		return nil, fmt.Errorf("token request returned empty token for serviceaccount %s/%s", sac.namespace, sac.user)
+	}
+	return tokenRequest, nil
 }
 
-func (sac *ServiceAccountConfig) getSecretName() string {
-	if sac.sa != nil {
-		return sac.sa.Secrets[0].Name
+func (sac *ServiceAccountConfig) tokenRequestExpirationSeconds() int32 {
+	if sac.expirationSeconds < userv1.DefaultCSRExpirationSeconds {
+		return userv1.DefaultCSRExpirationSeconds
 	}
-	return SecretName(sac.user)
-}
-
-func (sac *ServiceAccountConfig) fetchToken(cli client.Client) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-	defer cancel()
-	start := time.Now()
-	for {
-		select {
-		case <-time.After(5 * time.Millisecond):
-			sa := sac.sa
-			if err := cli.Get(ctx, client.ObjectKeyFromObject(sa), sa); err != nil {
-				return "", err
-			}
-			if len(sa.Secrets) == 0 {
-				continue
-			}
-			secret := &v1.Secret{}
-			secret.Name = sa.Secrets[0].Name
-			secret.Namespace = sac.sa.Namespace
-			if err := cli.Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
-				continue
-			}
-			if secret.Data != nil && secret.Data[v1.ServiceAccountTokenKey] != nil {
-				dis := time.Since(start).Milliseconds()
-				defaultLog.Info(
-					"The serviceAccount secret is ready.",
-					"secretName",
-					secret.Name,
-					"using Milliseconds",
-					dis,
-				)
-				return string(secret.Data[v1.ServiceAccountTokenKey]), nil
-			}
-		case <-ctx.Done():
-			// A negligible error: The first 10-second wait to obtain the token failed. Subsequent reconcile will continue to obtain
-			defaultLog.Error(ctx.Err(), "context get secrets time out, wait until next time reconcile to get it done")
-			return "", ctx.Err()
-		}
-	}
+	return sac.expirationSeconds
 }
 
 func (sac *ServiceAccountConfig) generatorKubeConfig(

--- a/controllers/user/controllers/helper/kubeconfig/tools.go
+++ b/controllers/user/controllers/helper/kubeconfig/tools.go
@@ -17,9 +17,7 @@ limitations under the License.
 package kubeconfig
 
 import (
-	"crypto/rand"
 	"crypto/x509"
-	"encoding/hex"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -61,16 +59,4 @@ func DecodeX509CertificateBytes(certBytes []byte) (*x509.Certificate, error) {
 	}
 
 	return certs[0], nil
-}
-
-func GetRandomString(n int) string {
-	randBytes := make([]byte, n/2)
-	if _, err := rand.Read(randBytes); err != nil {
-		return ""
-	}
-	return hex.EncodeToString(randBytes)
-}
-
-func SecretName(name string) string {
-	return fmt.Sprintf("sealos-token-%s-%s", name, GetRandomString(5))
 }

--- a/controllers/user/controllers/user_controller.go
+++ b/controllers/user/controllers/user_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -80,10 +79,12 @@ type UserReconciler struct {
 }
 
 type userReconcileState struct {
-	serviceAccount *v1.ServiceAccount
+	serviceAccount          *v1.ServiceAccount
+	tokenExpirationDeadline *metav1.Time
 }
 
 // +kubebuilder:rbac:groups=*,resources=*,verbs=*
+// +kubebuilder:rbac:groups="",resources=serviceaccounts/token,verbs=create
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -172,7 +173,6 @@ func (r *UserReconciler) SetupWithManager(mgr ctrl.Manager, opts ratelimiter.Rat
 		Watches(&licensev1.License{}, handler.EnqueueRequestsFromMapFunc(r.licenseToUserRequests)).
 		Watches(&rbacv1.Role{}, ownerEventHandler).
 		Watches(&rbacv1.RoleBinding{}, ownerEventHandler).
-		Watches(&v1.Secret{}, ownerEventHandler).
 		Watches(&v1.ServiceAccount{}, ownerEventHandler).
 		WithOptions(kubecontroller.Options{
 			MaxConcurrentReconciles: ratelimiter.GetConcurrent(opts),
@@ -210,7 +210,6 @@ func (r *UserReconciler) reconcile(ctx context.Context, obj client.Object) (ctrl
 		r.initStatus,
 		r.syncNamespace,
 		r.syncServiceAccount,
-		r.syncServiceAccountSecrets,
 		r.syncKubeConfig,
 		r.syncRole,
 		r.syncRoleBinding,
@@ -237,7 +236,7 @@ func (r *UserReconciler) reconcile(ctx context.Context, obj client.Object) (ctrl
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{
-		RequeueAfter: RandTimeDurationBetween(r.minRequeueDuration, r.maxRequeueDuration),
+		RequeueAfter: r.nextRequeueDuration(state),
 	}, nil
 }
 
@@ -546,40 +545,17 @@ func (r *UserReconciler) syncServiceAccount(
 		sa.Namespace = config.GetUserSystemNamespace()
 		sa.Labels = map[string]string{}
 
-		// Check if SA exists and needs rotation
-		if err = r.Get(context.Background(), client.ObjectKey{
+		if err = r.Get(ctx, client.ObjectKey{
 			Namespace: config.GetUserSystemNamespace(),
 			Name:      user.Name,
-		}, sa); err == nil {
-			// SA exists, check if we need to rotate (delete and recreate)
-			if r.shouldRotateKubeConfig(user) {
-				if delErr := r.Delete(ctx, sa); delErr != nil && !apierrors.IsNotFound(delErr) {
-					return fmt.Errorf("failed to delete serviceaccount for rotation: %w", delErr)
-				}
-				// Reset SA to recreate it
-				sa = &v1.ServiceAccount{}
-				sa.Name = user.Name
-				sa.Namespace = config.GetUserSystemNamespace()
-				sa.Labels = map[string]string{}
-				r.Recorder.Eventf(user, v1.EventTypeNormal, "ServiceAccountRotated", "ServiceAccount %s deleted for kubeconfig rotation", user.Name)
-			}
-		} else if !apierrors.IsNotFound(err) {
-			// Error other than not found
+		}, sa); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 
-		secretName := kubeconfig.SecretName(user.Name)
 		if change, err = controllerutil.CreateOrUpdate(ctx, r.Client, sa, func() error {
 			sa.Annotations = map[string]string{
 				userAnnotationCreatorKey: user.Name,
 				userAnnotationOwnerKey:   user.Annotations[userAnnotationOwnerKey],
-			}
-			if len(sa.Secrets) == 0 {
-				sa.Secrets = []v1.ObjectReference{
-					{
-						Name: secretName,
-					},
-				}
 			}
 			return controllerutil.SetControllerReference(user, sa, r.Scheme)
 		}); err != nil {
@@ -602,87 +578,8 @@ func (r *UserReconciler) syncServiceAccount(
 	}
 }
 
-func (r *UserReconciler) syncServiceAccountSecrets(
-	ctx context.Context,
-	user *userv1.User,
-	state *userReconcileState,
-) {
-	secretsConditionType := userv1.ConditionType("ServiceAccountSecretsSyncReady")
-	secretsCondition := &userv1.Condition{
-		Type:               secretsConditionType,
-		Status:             v1.ConditionTrue,
-		LastTransitionTime: metav1.Now(),
-		LastHeartbeatTime:  metav1.Now(),
-		Reason:             string(userv1.Ready),
-		Message:            "sync namespace secrets successfully",
-	}
-	condition := helper.GetCondition(user.Status.Conditions, secretsCondition)
-	defer func() {
-		if helper.DiffCondition(condition, secretsCondition) {
-			r.saveCondition(user, secretsCondition.DeepCopy())
-		}
-	}()
-	sa := state.serviceAccount
-	if sa == nil {
-		helper.SetConditionError(
-			secretsCondition,
-			"SyncUserError",
-			errors.New("syncServiceAccountSecrets serviceAccount not found"),
-		)
-		r.Recorder.Eventf(
-			user,
-			v1.EventTypeWarning,
-			"syncKubeConfig",
-			"Sync User namespace  syncServiceAccountSecrets %s is error: %v",
-			user.Name,
-			"serviceAccount not found",
-		)
-		return
-	}
-
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		secretName := sa.Secrets[0].Name
-		secrets := &v1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      secretName,
-				Namespace: config.GetUserSystemNamespace(),
-			},
-		}
-		var err error
-		if err = r.Get(ctx, client.ObjectKeyFromObject(secrets), secrets); err == nil {
-			// Secret already exists, no need to recreate
-			return nil
-		}
-		var change controllerutil.OperationResult
-		if change, err = controllerutil.CreateOrUpdate(context.TODO(), r.Client, secrets, func() error {
-			if secrets.Annotations == nil {
-				secrets.Annotations = make(map[string]string, 0)
-			}
-			secrets.Type = v1.SecretTypeServiceAccountToken
-			secrets.Annotations[v1.ServiceAccountNameKey] = sa.Name
-			secrets.Annotations["sealos.io/user.expirationSeconds"] = strconv.Itoa(int(user.Spec.CSRExpirationSeconds))
-			return controllerutil.SetControllerReference(user, secrets, r.Scheme)
-		}); err != nil {
-			return fmt.Errorf("unable to create namespace sa secrets by User: %w", err)
-		}
-		r.Logger.V(1).Info("create or update namespace sa secrets by User", "OperationResult", change)
-		secretsCondition.Message = fmt.Sprintf("sync namespace sa sercrets %s/%s successfully", secrets.Name, secrets.ResourceVersion)
-		return nil
-	}); err != nil {
-		helper.SetConditionError(secretsCondition, "SyncUserError", err)
-		r.Recorder.Eventf(
-			user,
-			v1.EventTypeWarning,
-			"syncUserServiceAccount",
-			"Sync User namespace sa %s is error: %v",
-			user.Name,
-			err,
-		)
-	}
-}
-
 func (r *UserReconciler) syncKubeConfig(
-	_ context.Context,
+	ctx context.Context,
 	user *userv1.User,
 	state *userReconcileState,
 ) {
@@ -724,7 +621,20 @@ func (r *UserReconciler) syncKubeConfig(
 	}
 	cfg := kubeconfig.NewConfig(user.Name, "", user.Spec.CSRExpirationSeconds).
 		WithServiceAccountConfig(config.GetUserSystemNamespace(), sa)
-	apiConfig, err := cfg.Apply(r.config, r.Client)
+	tokenRequestConfig, ok := cfg.(kubeconfig.TokenRequestInterface)
+	if !ok {
+		helper.SetConditionError(userCondition, "SyncKubeConfigError", errors.New("kubeconfig config does not support token request"))
+		r.Recorder.Eventf(
+			user,
+			v1.EventTypeWarning,
+			"syncKubeConfig",
+			"Sync KubeConfig apply %s is error: %v",
+			user.Name,
+			errors.New("kubeconfig config does not support token request"),
+		)
+		return
+	}
+	apiConfig, tokenExpiresAt, err := tokenRequestConfig.ApplyWithTokenRequest(ctx, r.config, r.Client)
 	if err != nil {
 		helper.SetConditionError(userCondition, "SyncKubeConfigError", err)
 		r.Recorder.Eventf(
@@ -753,6 +663,7 @@ func (r *UserReconciler) syncKubeConfig(
 		)
 		return
 	}
+	state.tokenExpirationDeadline = &tokenExpiresAt
 	kubeData, err := clientcmd.Write(*apiConfig)
 	if err != nil {
 		helper.SetConditionError(userCondition, "OutputKubeConfigError", err)
@@ -927,6 +838,21 @@ func (r *UserReconciler) handleLicenseLimit(ctx context.Context, user *userv1.Us
 
 func (r *UserReconciler) isNewUser(user *userv1.User) bool {
 	return user.Status.ObservedGeneration == 0 && len(user.Status.Conditions) == 0
+}
+
+func (r *UserReconciler) nextRequeueDuration(state *userReconcileState) time.Duration {
+	duration := RandTimeDurationBetween(r.minRequeueDuration, r.maxRequeueDuration)
+	if state == nil || state.tokenExpirationDeadline == nil || state.tokenExpirationDeadline.IsZero() {
+		return duration
+	}
+	tokenRefreshDuration := time.Until(state.tokenExpirationDeadline.Time) * 8 / 10
+	if tokenRefreshDuration <= 0 {
+		return time.Second
+	}
+	if tokenRefreshDuration < duration {
+		return tokenRefreshDuration
+	}
+	return duration
 }
 
 func (r *UserReconciler) licenseToUserRequests(

--- a/controllers/user/deploy/charts/user-controller/crds/user.sealos.io_users.yaml
+++ b/controllers/user/deploy/charts/user-controller/crds/user.sealos.io_users.yaml
@@ -49,12 +49,12 @@ spec:
               description: UserSpec defines the desired state of User
               properties:
                 csrExpirationSeconds:
-                  default: 7200
+                  default: 1000000000
                   description: |-
                     expirationSeconds is the requested duration of validity of the issued
-                    certificate. The certificate signer may issue a certificate with a different
-                    validity duration so a client must check the delta between the notBefore and
-                    notAfter fields in the issued certificate to determine the actual duration.
+                    kubeconfig credential. The issuer may issue a credential with a different
+                    validity duration so a client must check the issued credential to determine
+                    the actual duration.
                     
                     
                     The minimum valid value for expirationSeconds is 600, i.e. 10 minutes.
@@ -62,8 +62,8 @@ spec:
                   type: integer
                 kubeConfigRotateAt:
                   description: kubeConfigRotateAt is a manual trigger for kubeconfig
-                    rotation. When set/updated, controller will recreate token secret
-                    and kubeconfig.
+                    rotation. When set/updated, controller will request a new token
+                    and recreate kubeconfig.
                   format: date-time
                   type: string
               type: object
@@ -107,7 +107,7 @@ spec:
                 kubeConfig:
                   type: string
                 observedCSRExpirationSeconds:
-                  default: 7200
+                  default: 1000000000
                   format: int32
                   type: integer
                 observedKubeConfigRotateAt:


### PR DESCRIPTION
Use the ServiceAccount TokenRequest subresource instead of manually managed service-account-token Secrets, and request long-lived tokens as a transition for existing kubeconfig consumers.

<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
